### PR TITLE
Palette hand swap fix - rays should adjust correctly.

### DIFF
--- a/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteHandManager.cs
+++ b/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteHandManager.cs
@@ -168,80 +168,6 @@ public class PaletteHandManager : MonoBehaviour
         OnHandChange?.Invoke(isLeftHandDominant.IsToggled);
     }
 
-    /*public void UpdateHand(NetworkContext context, ParentConstraint parentConstraint, Ubiq.Avatars.Avatar[] avatars, ParentConstraint otherPaletteParentConstraint, string paletteType, bool handStateAlreadyFound)
-    {
-        // Debug.Log("Called UpdateHand() from palette " + gameObject.name + " in scene " + gameObject.transform.parent.parent.parent.name);
-        // Go through every avatar looking for the palette owner's avatar.
-        // Only put a parent constraint for the owner's palette (if the first avatar found is the owner)
-        for (int i = 0; i < avatars.Length; i++)
-        {
-            if (avatars[i].ToString().Contains("My Avatar"))
-            {
-                // By default the dominant hand is assigned to the right hand
-                // This is very dependent on Ubiq implementation but likely has to be.
-                Transform dominantHand = avatars[i].transform.Find("Body/Floating_LeftHand_A");
-
-                // Update the dominant hand based on the toggle state of the Switch Hands Button
-                if (isLeftHandDominant.IsToggled)
-                {
-                    dominantHand = avatars[i].transform.Find("Body/Floating_RightHand_A");
-
-                    // If the rotation offset y is negative then make it positive to reflect the orientation of a left hand perspective
-                    if (Mathf.Sign(parentConstraint.GetRotationOffset(0).y) == -1)
-                    {
-                        parentConstraint.SetRotationOffset(0, Vector3.Scale(parentConstraint.GetRotationOffset(0), new Vector3(1, -1, 1)));
-                    }
-
-                    // Disable and enable the appropriate selectors for a dominant left hand
-                    leftHandRay.SetActive(true);
-                    leftHandPokeInteractor.SetActive(true);
-
-                    StartCoroutine(disableController(0.25f, GameObject.Find("Player (XRI + WebXR)/MRTK XR Rig/Camera Offset/MRTK RightHand Controller/Far Ray"),
-                                    GameObject.Find("Player (XRI + WebXR)/MRTK XR Rig/Camera Offset/MRTK RightHand Controller/IndexTip PokeInteractor")));
-                }
-                else if (!isLeftHandDominant.IsToggled)
-                {
-                    dominantHand = avatars[i].transform.Find("Body/Floating_LeftHand_A");
-
-                    // If the rotation offset y is positive then make it negative to reflect the orientation of a right hand perspective
-                    if (Mathf.Sign(parentConstraint.GetRotationOffset(0).y) == 1)
-                    {
-                        parentConstraint.SetRotationOffset(0, Vector3.Scale(parentConstraint.GetRotationOffset(0), new Vector3(1, -1, 1)));
-                    }
-
-                    // Disable and enable the appropriate selectors for a dominant right hand
-                    rightHandRay.SetActive(true);
-                    rightHandPokeInteractor.SetActive(true);
-
-                    StartCoroutine(disableController(0.25f, GameObject.Find("Player (XRI + WebXR)/MRTK XR Rig/Camera Offset/MRTK LeftHand Controller/Far Ray"),
-                                    GameObject.Find("Player (XRI + WebXR)/MRTK XR Rig/Camera Offset/MRTK LeftHand Controller/IndexTip PokeInteractor")));
-                }
-
-                // By default, parent constraint is set to false in the inspector. Turn it on only for the client. If parent
-                // constraints are on for both client and server-side peers the palette will not function correctly and flicker.
-                parentConstraint.constraintActive = true;
-
-                // Add the LeftHand Controller as an argument for Parent Constraint
-                constraintSource.sourceTransform = dominantHand;
-
-                // Set the weight to 1 instead of default 0
-                constraintSource.weight = 1;
-                parentConstraint.SetSource(0, constraintSource);
-
-                // Change which grip button determines the toggle ability of the palette
-                ChangeGripButton();
-                break;
-            }
-            else 
-            {
-                i++;
-            }
-                
-        }
-
-        OnHandChange?.Invoke(isLeftHandDominant.IsToggled);
-    }*/
-
     public OnButtonPress left;
     public OnButtonPress right;
     public void ChangeGripButton()
@@ -284,7 +210,8 @@ public class PaletteHandManager : MonoBehaviour
         pokeInteractor.SetActive(false);
     }
 
-    // This method does not wait, is it necessary to wait?
+    // This method does not wait, is it necessary to wait like above?
+    // Will disable the controller that is holding the palette determined by isLeftHandDominant
     public void disableControllerOnReopen()
     {
         // If the dominant hand is set, turn off the corresponding rays.

--- a/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteHandManager.cs
+++ b/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteHandManager.cs
@@ -108,7 +108,7 @@ public class PaletteHandManager : MonoBehaviour
                     leftHandRay.SetActive(true);
                     leftHandPokeInteractor.SetActive(true);
 
-                    StartCoroutine(disableController(0.25f, GameObject.Find("Player (XRI + WebXR)/MRTK XR Rig/Camera Offset/MRTK LeftHand Controller/Far Ray"),
+                    StartCoroutine(disableController(0.25f, GameObject.Find("Player (XRI + WebXR)/MRTK XR Rig/Camera Offset/MRTK RightHand Controller/Far Ray"),
                                     GameObject.Find("Player (XRI + WebXR)/MRTK XR Rig/Camera Offset/MRTK RightHand Controller/IndexTip PokeInteractor")));
                 }
                 else if (!isLeftHandDominant.IsToggled)
@@ -248,7 +248,7 @@ public class PaletteHandManager : MonoBehaviour
     {
         try
         {
-            if (isLeftHandDominant.IsToggled)
+            /*if (isLeftHandDominant.IsToggled)
             {
                 left.enabled = false;
                 right.enabled = true;
@@ -260,12 +260,20 @@ public class PaletteHandManager : MonoBehaviour
                 right.enabled = false;
                 // paletteManager.GetComponents<OnButtonPress>()[0].enabled = true;
                 // paletteManager.GetComponents<OnButtonPress>()[1].enabled = false;
-            }
+            }*/
         }
         catch (NullReferenceException e)
         {
             Debug.Log(e);
         }
+    }
+
+    public void EnableAllControlsOnPaletteClose()
+    {
+        leftHandRay.SetActive(true);
+        leftHandPokeInteractor.SetActive(true);
+        rightHandRay.SetActive(true);
+        rightHandPokeInteractor.SetActive(true);
     }
 
     // Disable the previous dominant controller after a slight interval to avoid button states locking into place

--- a/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteHandManager.cs
+++ b/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteHandManager.cs
@@ -283,4 +283,22 @@ public class PaletteHandManager : MonoBehaviour
         farRay.SetActive(false);
         pokeInteractor.SetActive(false);
     }
+
+    // This method does not wait, is it necessary to wait?
+    public void disableControllerOnReopen()
+    {
+        // If the dominant hand is set, turn off the corresponding rays.
+        if (isLeftHandDominant != null)
+        {
+            if(isLeftHandDominant.IsToggled)
+            {
+                rightHandRay.SetActive(false);
+                rightHandPokeInteractor.SetActive(false);
+            } else
+            {
+                leftHandRay.SetActive(false);
+                leftHandPokeInteractor.SetActive(false);
+            }
+        }
+    }
 }

--- a/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteSpawner.cs
+++ b/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteSpawner.cs
@@ -6,6 +6,7 @@ using Ubiq.Spawning;
 using Microsoft.MixedReality.Toolkit;
 using Microsoft.MixedReality.Toolkit.UX;
 using Microsoft.MixedReality.Toolkit.SpatialManipulation;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 
 
 /// <summary>
@@ -151,7 +152,6 @@ public class PaletteSpawner : MonoBehaviour
             {
                 PaletteHandManager phm = palette.GetComponent<PaletteHandManager>();
                 phm.EnableAllControlsOnPaletteClose();
-                //phm.left.enabled = false;
             }
            
 
@@ -172,8 +172,8 @@ public class PaletteSpawner : MonoBehaviour
             if(palette != null)
             {
                 PaletteHandManager phm = palette.GetComponent<PaletteHandManager>();
-                //phm.EnableAllControlsOnPaletteClose();
-                phm.left.enabled = false;
+                phm.disableControllerOnReopen();
+             
             }
             // Hide the current palette that is being used
             if (paletteSwitcher.networkedPlayManager.playMode)

--- a/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteSpawner.cs
+++ b/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteSpawner.cs
@@ -147,6 +147,14 @@ public class PaletteSpawner : MonoBehaviour
         // all scripts which would not allow the user to use any functions from the palette.
         else if (paletteShown)
         {
+            if(palette != null)
+            {
+                PaletteHandManager phm = palette.GetComponent<PaletteHandManager>();
+                phm.EnableAllControlsOnPaletteClose();
+                //phm.left.enabled = false;
+            }
+           
+
             // Hide the current palette that is being used
             if (paletteSwitcher.networkedPlayManager.playMode)
             {
@@ -161,6 +169,12 @@ public class PaletteSpawner : MonoBehaviour
         }
         else if (!paletteShown)
         {
+            if(palette != null)
+            {
+                PaletteHandManager phm = palette.GetComponent<PaletteHandManager>();
+                //phm.EnableAllControlsOnPaletteClose();
+                phm.left.enabled = false;
+            }
             // Hide the current palette that is being used
             if (paletteSwitcher.networkedPlayManager.playMode)
             {

--- a/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteSpawner.cs
+++ b/Unity/Assets/RealityFlow Modeler/Runtime/Palette/PaletteSpawner.cs
@@ -28,50 +28,6 @@ public class PaletteSpawner : MonoBehaviour
     private Vector3 paletteSize;
     private Vector3 playPaletteSize;
 
-    /*public void SpawnPalette()
-    {
-        Vector3 paletteSize = palettePrefab.transform.localScale;
-
-        // If the palette is not in the current scene, then spawn it in
-        if(palette == null)
-        {
-            // Debug.Log("SpawnPalette() was triggered to spawn a palette");
-            palette = NetworkSpawnManager.Find(this).SpawnWithPeerScope(palettePrefab);
-            PaletteHandManager phm = palette.GetComponent<PaletteHandManager>();
-            phm.paletteManager = gameObject;
-            phm.left = GetComponents<OnButtonPress>()[0];
-            phm.right = GetComponents<OnButtonPress>()[1];
-            phm.left.enabled = false;
-            paletteShown = true;
-
-            // Set the ownership of the spawned palette to the user who spawned it
-            palette.GetComponent<NetworkedPalette>().owner = true;
-            //palette.GetComponent<NetworkedPalette>().needData = true;
-
-            try
-            {
-                isLeftHandDominant = GameObject.FindGameObjectsWithTag("DominantHandManager")[0].GetComponent<PressableButton>();
-                Debug.Log(GameObject.FindGameObjectsWithTag("DominantHandManager")[0]);
-            }
-            catch (IndexOutOfRangeException e)
-            {
-                Debug.Log(e + " Has the palette been spawned in your scene?");
-            }
-        }
-        // We set the scale of the palette to 0 to effectively hide it. We do not disable it in the hierarchy as this will turn off
-        // all scripts which would not allow the user to use any functions from the palette.
-        else if (paletteShown)
-        {
-            palette.transform.localScale = new Vector3(0, 0, 0);
-            paletteShown = false;
-        }
-        else if (!paletteShown)
-        {
-            palette.transform.localScale = paletteSize;
-            paletteShown = true;
-        }
-    }*/
-
     void Start()
     {
         paletteSwitcher = gameObject.GetComponent<PaletteSwitcher>();
@@ -144,10 +100,13 @@ public class PaletteSpawner : MonoBehaviour
                 playPalette.transform.localScale = new Vector3(0, 0, 0);
             }
         }
+
         // We set the scale of the palette to 0 to effectively hide it. We do not disable it in the hierarchy as this will turn off
         // all scripts which would not allow the user to use any functions from the palette.
         else if (paletteShown)
         {
+
+            // If the palette exists and is closing, we re-enable rays
             if(palette != null)
             {
                 PaletteHandManager phm = palette.GetComponent<PaletteHandManager>();
@@ -169,6 +128,8 @@ public class PaletteSpawner : MonoBehaviour
         }
         else if (!paletteShown)
         {
+            // If the palette exists and is opened/reactivated, disable the appropriate controls 
+            // (the hand holding palette should be inactive)
             if(palette != null)
             {
                 PaletteHandManager phm = palette.GetComponent<PaletteHandManager>();

--- a/Unity/ProjectSettings/EditorBuildSettings.asset
+++ b/Unity/ProjectSettings/EditorBuildSettings.asset
@@ -38,5 +38,5 @@ EditorBuildSettings:
       type: 2}
     com.unity.xr.management.loader_settings: {fileID: 11400000, guid: e73ad9fc6dbc18642acd1175f6a4492e,
       type: 2}
-    com.unity.xr.openxr.settings4: {fileID: 11400000, guid: 6095c1a49f5cfbc488682a7a8f8f2b6c,
+    com.unity.xr.openxr.settings4: {fileID: 11400000, guid: 7123b93ddaaba4de594425d744df5993,
       type: 2}


### PR DESCRIPTION
Using the palette (Palette Test With Play/Edit Scene), opening the palette, swapping hands, closing and reopening the palette, switching to the play mode palette, should all maintain expected interactors. (rays turned off when palette is opened for that hand and turn on when palette is closed closed).