### PR TITLE
Added undo logic for node operations

### DIFF
--- a/Unity/Assets/RealityFlow/Node Graph/Graph.cs
+++ b/Unity/Assets/RealityFlow/Node Graph/Graph.cs
@@ -486,6 +486,27 @@ namespace RealityFlow.NodeGraph
         public ImmutableList<NodeIndex> GetExecutionInputPortsOf(PortIndex outputPort)
             => executionEdges[outputPort];
 
+        public void ApplyJson(string json)
+        {
+            Graph fromJson = JsonUtility.FromJson<Graph>(json);
+
+            id = fromJson.id;
+            name = fromJson.name;
+            nodes = fromJson.nodes;
+            nodeTypes = fromJson.nodeTypes;
+            reverseEdges = fromJson.reverseEdges;
+            executionEdges = fromJson.executionEdges;
+            inputPorts = fromJson.inputPorts;
+            outputPorts = fromJson.outputPorts;
+            reverseInputPortEdges = fromJson.reverseInputPortEdges;
+            reverseOutputPortEdges = fromJson.reverseOutputPortEdges;
+            executionInputs = fromJson.executionInputs;
+            inputExecutionEdges = fromJson.inputExecutionEdges;
+            variadicPassthrough = fromJson.variadicPassthrough;
+            variadicOutput = fromJson.variadicOutput;
+            variables = fromJson.variables;
+        }
+
         public void OnBeforeSerialize() { }
 
         public void OnAfterDeserialize()

--- a/Unity/Assets/RealityFlow/Node Graph/Graph.cs
+++ b/Unity/Assets/RealityFlow/Node Graph/Graph.cs
@@ -143,13 +143,20 @@ namespace RealityFlow.NodeGraph
         public ImmutableDictionary<string, NodeValueType> Variables
             => variables.ToImmutableDictionary();
 
+        public int ChangeTicks { get; private set; }
+
+        public void IncrementChangeTicks()
+            => ChangeTicks += 1;
+
         public void AddVariable(string name, NodeValueType type)
         {
+            IncrementChangeTicks();
             variables.Add(name, type);
         }
 
         public void RemoveVariable(string name)
         {
+            IncrementChangeTicks();
             variables.Remove(name);
         }
 
@@ -168,6 +175,7 @@ namespace RealityFlow.NodeGraph
             Node node = new(definition);
             NodeIndex index = nodes.Add(node);
             MutableNodesOfType(definition.Name).Add(index);
+            IncrementChangeTicks();
             return index;
         }
 
@@ -228,9 +236,14 @@ namespace RealityFlow.NodeGraph
                             executionEdges.Remove(from, index);
 
                 MutableNodesOfType(node.Definition.name).Remove(index);
+
+                IncrementChangeTicks();
             }
 
-            return nodes.Remove(index);
+            if (nodes.Remove(index) == false)
+                Debug.LogError("Failed to remove existing node");
+
+            return true;
         }
 
         public Node GetNode(NodeIndex index)
@@ -307,6 +320,7 @@ namespace RealityFlow.NodeGraph
                 return false;
 
             reverseEdges.Add(new(to, toPort), new(from, fromPort));
+            IncrementChangeTicks();
             return true;
         }
 
@@ -462,6 +476,8 @@ namespace RealityFlow.NodeGraph
 
             executionEdges.Add(new(from, fromPort), to);
 
+            IncrementChangeTicks();
+
             return true;
         }
 
@@ -473,11 +489,15 @@ namespace RealityFlow.NodeGraph
         public void RemoveDataEdge(PortIndex from, PortIndex to)
         {
             reverseEdges.Remove(to);
+
+            IncrementChangeTicks();
         }
 
         public void RemoveExecutionEdge(PortIndex from, NodeIndex to)
         {
             executionEdges.Remove(from, to);
+
+            IncrementChangeTicks();
         }
 
         public bool TryGetOutputPortOf(PortIndex inputPort, out PortIndex outputPort)
@@ -505,6 +525,8 @@ namespace RealityFlow.NodeGraph
             variadicPassthrough = fromJson.variadicPassthrough;
             variadicOutput = fromJson.variadicOutput;
             variables = fromJson.variables;
+
+            IncrementChangeTicks();
         }
 
         public void OnBeforeSerialize() { }

--- a/Unity/Assets/RealityFlow/Node UI/GraphView.cs
+++ b/Unity/Assets/RealityFlow/Node UI/GraphView.cs
@@ -35,7 +35,8 @@ namespace RealityFlow.NodeUI
         public GameObject nodeUIPrefab;
         public GameObject edgeUIPrefab;
 
-        bool dirty;
+        int lastChangeTicks;
+        bool Dirty => graph.ChangeTicks != lastChangeTicks;
         VisualScript currentObject;
         public VisualScript CurrentObject { get => currentObject; set => currentObject = value; }
         string selectedVariable;
@@ -85,17 +86,16 @@ namespace RealityFlow.NodeUI
                 return;
             }
 
-            if (dirty)
+            if (Dirty)
             {
                 Render();
-                dirty = false;
+                MarkClean();
             }
         }
 
-        public void MarkDirty()
-        {
-            dirty = true;
-        }
+        public void MarkDirty() => graph.IncrementChangeTicks();
+
+        void MarkClean() => lastChangeTicks = graph.ChangeTicks;
 
         public void OnPointerDown(PointerEventData eventData)
         {

--- a/Unity/Assets/RealityFlow/Scripts/API/RealityFlowAPI.cs
+++ b/Unity/Assets/RealityFlow/Scripts/API/RealityFlowAPI.cs
@@ -661,7 +661,7 @@ public class RealityFlowAPI : MonoBehaviour, INetworkSpawnable
         Debug.Log($"Setting node {node} port {port} constant to {value}");
 
         if (!isUndoing)
-            actionLogger.LogAction(nameof(SetNodeFieldValue), graph, node, port, oldValue, prevJson);
+            actionLogger.LogAction(nameof(SetNodeInputConstantValue), graph, node, port, oldValue, prevJson);
 
         SendGraphUpdateToDatabase(graphJson, graph.Id);
 


### PR DESCRIPTION
Redo logic not added because no redo logic appears to be used.
~~Cannot test because undo is disabled currently.~~ EDIT: Tested using editor button to undo directly on RealityFlowAPI

~~Ideally undo would be re-enabled and this PR tested before merging.~~