### PR TITLE
Add variable nodes for every value type other than int

### DIFF
--- a/Unity/Assets/RealityFlow/Node Graph/NodeFieldDefinition.cs
+++ b/Unity/Assets/RealityFlow/Node Graph/NodeFieldDefinition.cs
@@ -18,6 +18,12 @@ namespace RealityFlow.NodeGraph
         [SerializeReference]
         [DiscUnion]
         public NodeValue DefaultValue;
+        /// <summary>
+        /// Only valid if DefaultType == NodeValueType.Variable
+        /// 
+        /// Represents the type of the variables this field can reference
+        /// </summary>
+        public NodeValueType VariableType;
 
         public readonly string GetDescriptor()
         {

--- a/Unity/Assets/RealityFlow/Node Graph/NodeValueWrapper.cs
+++ b/Unity/Assets/RealityFlow/Node Graph/NodeValueWrapper.cs
@@ -1,15 +1,18 @@
 using UnityEngine;
 using System;
 
-namespace RealityFlow.NodeGraph{[Serializable]public struct NodeValueWrapper
-{
-        [SerializeReference]
-        [DiscUnion]
-        NodeValue value;
-        public NodeValue Value => value;
+namespace RealityFlow.NodeGraph{
+    [Serializable]
+    public struct NodeValueWrapper
+    {
+            [SerializeReference]
+            [DiscUnion]
+            NodeValue value;
+            public NodeValue Value => value;
 
-        public NodeValueWrapper(NodeValue value)
-        {
-            this.value = value;
-        }
-}}
+            public NodeValueWrapper(NodeValue value)
+            {
+                this.value = value;
+            }
+    }
+}

--- a/Unity/Assets/RealityFlow/Node UI/NodePalette.cs
+++ b/Unity/Assets/RealityFlow/Node UI/NodePalette.cs
@@ -23,6 +23,7 @@ namespace RealityFlow.NodeUI
                 .NodeDefinitionDict
                 .Values
                 .Where(def => whitelist == null || whitelist.Contains(def.Name))
+                .OrderBy(def => def.Name)
                 .ToList();
 
             page.OnShow = (element, index) =>
@@ -34,6 +35,23 @@ namespace RealityFlow.NodeUI
                 button.definition = defs[index];
             };
             page.ItemCount = defs.Count;
+        }
+    }
+
+    internal class NewClass
+    {
+        public NewClass()
+        {
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is NewClass other;
+        }
+
+        public override int GetHashCode()
+        {
+            return 0;
         }
     }
 }

--- a/Unity/Assets/RealityFlow/Node UI/NodeView.cs
+++ b/Unity/Assets/RealityFlow/Node UI/NodeView.cs
@@ -129,6 +129,10 @@ namespace RealityFlow.NodeUI
                     Debug.LogError("Failed to get field value on Render()");
                     fieldValue = def.DefaultValue;
                 }
+                if (editor is VariableEditor varEditor)
+                {
+                    varEditor.Type = view.Graph.Variables[(string)fieldValue.DynValue];
+                }
 
                 editor.NodeValue = fieldValue;
                 editor.OnTick += value =>

--- a/Unity/Assets/RealityFlow/Node UI/NodeView.cs
+++ b/Unity/Assets/RealityFlow/Node UI/NodeView.cs
@@ -130,9 +130,7 @@ namespace RealityFlow.NodeUI
                     fieldValue = def.DefaultValue;
                 }
                 if (editor is VariableEditor varEditor)
-                {
-                    varEditor.Type = view.Graph.Variables[(string)fieldValue.DynValue];
-                }
+                    varEditor.Type = def.VariableType;
 
                 editor.NodeValue = fieldValue;
                 editor.OnTick += value =>

--- a/Unity/Assets/RealityFlow/Node UI/NodeView.cs
+++ b/Unity/Assets/RealityFlow/Node UI/NodeView.cs
@@ -47,6 +47,7 @@ namespace RealityFlow.NodeUI
                 [NodeValueType.Float] = Resources.Load<GameObject>(basePath + "Float Editor"),
                 [NodeValueType.Vector2] = Resources.Load<GameObject>(basePath + "Vector2 Editor"),
                 [NodeValueType.Vector3] = Resources.Load<GameObject>(basePath + "Vector3 Editor"),
+                [NodeValueType.Quaternion] = Resources.Load<GameObject>(basePath + "Quaternion Editor"),
                 [NodeValueType.String] = Resources.Load<GameObject>(basePath + "String Editor"),
                 [NodeValueType.GameObject] = Resources.Load<GameObject>(basePath + "GameObject Editor"),
                 [NodeValueType.TemplateObject] = Resources.Load<GameObject>(basePath + "TemplateObject Editor"),

--- a/Unity/Assets/RealityFlow/Node UI/Value Editors/QuaternionEditor.cs
+++ b/Unity/Assets/RealityFlow/Node UI/Value Editors/QuaternionEditor.cs
@@ -1,0 +1,30 @@
+using System;
+using RealityFlow.NodeGraph;
+using TMPro;
+using UnityEngine;
+
+namespace RealityFlow.NodeUI
+{
+    public class QuaternionEditor : MonoBehaviour, IValueEditor
+    {
+        [SerializeField]
+        TMP_Text title;
+
+        public TMP_Text Name => title;
+
+        public Action<NodeValue> OnTick { get; set; }
+
+        public object Value
+        {
+            get => null;
+            set { }
+        }
+
+        public NodeValue NodeValue { set { } }
+
+        public void Tick()
+        {
+            OnTick(null);
+        }
+    }
+}

--- a/Unity/Assets/RealityFlow/Node UI/Value Editors/QuaternionEditor.cs.meta
+++ b/Unity/Assets/RealityFlow/Node UI/Value Editors/QuaternionEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69b67357b5f92584292c5ac1a0706ad7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/RealityFlow/Node UI/Value Editors/VariableEditor.cs
+++ b/Unity/Assets/RealityFlow/Node UI/Value Editors/VariableEditor.cs
@@ -23,6 +23,8 @@ namespace RealityFlow.NodeUI
         Whiteboard whiteboard;
         readonly List<string> variables = new();
 
+        public NodeValueType Type { get; set; } = NodeValueType.Int;
+
         void OnEnable()
         {
             whiteboard = GetComponentInParent<Whiteboard>();
@@ -45,7 +47,7 @@ namespace RealityFlow.NodeUI
                 variables.Clear();
                 variables.AddRange(
                     whiteboard.TopLevelGraphView.Graph.Variables
-                    .Where(kv => kv.Value == NodeValueType.Int)
+                    .Where(kv => kv.Value == Type)
                     .Select(kv => kv.Key)
                 );
                 dropdown.ClearOptions();

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetAudioVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetAudioVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetAudioVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 13
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<string>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetAudioVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetAudioVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 13
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetAudioVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetAudioVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8029e286100d9474987933e8d1339914
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetBoolVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetBoolVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 6
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetBoolVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetBoolVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetBoolVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 6
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<bool>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetBoolVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetBoolVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea4e1fe82d2cfa34fbc4efed38189a94
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetFloatVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetFloatVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetFloatVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 1
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<float>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetFloatVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetFloatVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 1
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetFloatVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetFloatVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ff851323e737de418ba8c3a068942bb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetGameObjectVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetGameObjectVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 8
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetGameObjectVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetGameObjectVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetGameObjectVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 8
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<GameObject>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetGameObjectVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetGameObjectVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78bd71115a9173941b40e14d82c5d819
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetQuaternionVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetQuaternionVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 4
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetQuaternionVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetQuaternionVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetQuaternionVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 4
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<Quaternion>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetQuaternionVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetQuaternionVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8b03ab64b7ec5d4eac4d7e927ec7dc3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetStringVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetStringVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetStringVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 10
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<string>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetStringVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetStringVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 10
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetStringVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetStringVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c9ea079f554d7848b9247e2645e391a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTemplateObjectVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTemplateObjectVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 9
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTemplateObjectVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTemplateObjectVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetTemplateObjectVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 9
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<GameObject>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTemplateObjectVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTemplateObjectVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ee1faaf445aa3be43b6f50bcf716dd7d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTextVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTextVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 12
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTextVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTextVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetTextVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 12
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<GameObject>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTextVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetTextVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a05ba995e8774254d929e38413a11f49
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector2Variable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector2Variable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 2
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector2Variable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector2Variable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetVector2Variable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 2
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<Vector2>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector2Variable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector2Variable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: edbc3ff9105720545bed806710cdbebf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector3Variable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector3Variable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 3
   Inputs: []
   Outputs:
   - Name: value

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector3Variable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector3Variable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: GetVector3Variable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs: []
+  Outputs:
+  - Name: value
+    Optional: 0
+    Type: 3
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'value = ctx.GetVariable<Vector3>(variable);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector3Variable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/GetVector3Variable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 720e01c36418c234c84df1991db6c645
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetAudioVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetAudioVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 13
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetAudioVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetAudioVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetAudioVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 0
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetAudioVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetAudioVariable.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   Inputs:
   - Name: value
     Optional: 0
-    Type: 0
+    Type: 13
   Outputs: []
   IsVariadic: 0
   IsVariadicOutput: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetAudioVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetAudioVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 81638a603b093404392a9b35a97092da
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetBoolVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetBoolVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 6
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetBoolVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetBoolVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetBoolVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 6
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetBoolVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetBoolVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6e76e5e53c029b4eb4834aa5702e6e7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetFloatVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetFloatVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetFloatVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 1
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetFloatVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetFloatVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 1
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetFloatVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetFloatVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ea1ded73381538409b1d69ba2f29959
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetGameObjectVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetGameObjectVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 8
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetGameObjectVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetGameObjectVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetGameObjectVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 8
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetGameObjectVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetGameObjectVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59092ca5547ee31459e4159e342de3ff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetQuaternionVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetQuaternionVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetQuaternionVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 4
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetQuaternionVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetQuaternionVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 4
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetQuaternionVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetQuaternionVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c45980858d07fa8478101348ba0cbd0f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetStringVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetStringVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 10
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetStringVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetStringVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetStringVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 10
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetStringVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetStringVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8e477a7530d5b7449c33356dcc9e887
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTemplateObjectVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTemplateObjectVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 9
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTemplateObjectVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTemplateObjectVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetTemplateObjectVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 9
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTemplateObjectVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTemplateObjectVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d05a9822dfe9894aa24d7fc8de1f577
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTextVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTextVariable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 12
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTextVariable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTextVariable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetTextVariable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 12
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTextVariable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetTextVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 473b6a20f0639cb45b1f0735ef438323
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector2Variable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector2Variable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 2
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector2Variable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector2Variable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetVector2Variable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 2
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector2Variable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector2Variable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7781820ee32dff46a8954141b86a033
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector3Variable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector3Variable.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bec6d8e18daaab4e85909e6f63bdae2, type: 3}
+  m_Name: SetVector3Variable
+  m_EditorClassIdentifier: 
+  Fields:
+  - Name: variable
+    DefaultType: 11
+    DefaultValue:
+      rid: -2
+  Inputs:
+  - Name: value
+    Optional: 0
+    Type: 3
+  Outputs: []
+  IsVariadic: 0
+  IsVariadicOutput: 0
+  EvaluationMethod: 1
+  EvalLookup: 
+  EvalCode: 'ctx.SetVariable(variable, value);
+
+    then();'
+  ExecutionInput: 1
+  ExecutionOutputs:
+  - then
+  references:
+    version: 2
+    RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector3Variable.asset
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector3Variable.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
     DefaultType: 11
     DefaultValue:
       rid: -2
+    VariableType: 3
   Inputs:
   - Name: value
     Optional: 0

--- a/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector3Variable.asset.meta
+++ b/Unity/Assets/Resources/NodeGraph/Nodes/State/SetVector3Variable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d360039e94ad35449bca0adf3567c7ef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Resources/NodeUI/ValueEditors/Quaternion Editor.prefab
+++ b/Unity/Assets/Resources/NodeUI/ValueEditors/Quaternion Editor.prefab
@@ -1,0 +1,178 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2796228700254116886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3499246558055956239}
+  - component: {fileID: 700121548614976862}
+  - component: {fileID: 2336038506238371998}
+  - component: {fileID: 8482092656554716309}
+  - component: {fileID: 3509822207056180514}
+  m_Layer: 5
+  m_Name: Quaternion Editor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3499246558055956239
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2796228700254116886}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.000102996826}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &700121548614976862
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2796228700254116886}
+  m_CullTransparentMesh: 1
+--- !u!114 &2336038506238371998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2796228700254116886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Name
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
+  m_sharedMaterial: {fileID: -1005824763306460071, guid: 533bdd8d5c92b52448ee2ecf7bd828a4,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 8
+  m_fontSizeBase: 8
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &8482092656554716309
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2796228700254116886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &3509822207056180514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2796228700254116886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 69b67357b5f92584292c5ac1a0706ad7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  title: {fileID: 2336038506238371998}

--- a/Unity/Assets/Resources/NodeUI/ValueEditors/Quaternion Editor.prefab.meta
+++ b/Unity/Assets/Resources/NodeUI/ValueEditors/Quaternion Editor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9a7440d53db24734f9f0754ada9c8c4e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds missing variable nodes so that variables can be created for types other than int.

What to check for when reviewing:
- make sure nothing is generally broken, whiteboard seems functional, and variable nodes can be created for various types